### PR TITLE
47_feat/provide example data for seeding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'rspec-rails'
+  gem 'faker', '~> 1.7', '>= 1.7.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       activemodel
     erubis (2.7.0)
     execjs (2.6.0)
+    faker (1.7.2)
+      i18n (~> 0.5)
     geocoder (1.3.7)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -175,6 +177,7 @@ DEPENDENCIES
   byebug
   clearance
   coffee-rails (~> 4.1.0)
+  faker (~> 1.7, >= 1.7.2)
   geocoder
   jbuilder (~> 2.0)
   jquery-rails
@@ -190,4 +193,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,2 @@
+# Set API response timeout in seconds here (useful for seeding data into the database)
+Geocoder::Configuration.timeout = 60

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,22 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+# # This file should contain all the record creation needed to seed the database with its default values.
+# # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+# #
+# # Examples:
+# #
+# #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
+# #   Mayor.create(name: 'Emanuel', city: cities.first)
 #
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+
+cities = ["Hamburg", "Berlin", "München", "Frankfurt am Main", "Bremen", "Stuttgart", "Düsseldorf"]
+
+37.times do
+  name = Faker::Name.name
+  email = Faker::Internet.email
+  password = 'password'
+  User.create!(name: name,
+               email: email,
+               password: password,
+               password_confirmation: password,
+							 city: cities.sample,
+							 country: "de")
+end


### PR DESCRIPTION
This PR adds example user data records (37) to the database that is partly generated by the gem `faker` (name, email). 

Following parts are not generated by `faker`:
- `password` => password is hard-coded in case we want to test one of the user credentials (since we only use it in test and development environment it's okay to have this password visible I guess?)
- `cities` => cities are hard-coded and restricted to german cities for now (otherwise faker would generate random cities from USA)
- `countries` => we restrict the countries to be in `:de` for now, otherwise they won't match with the german cities

This resolves Github issue: #47.

**Example Result:**

<img width="1273" alt="00000253" src="https://cloud.githubusercontent.com/assets/4077916/22447324/24a43b48-e752-11e6-8586-71971507da87.png">

