### PR TITLE
Add waffle info and short slam alphas description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# slam-alphas
+# Slam Alphas App
+[![Stories in Ready](https://badge.waffle.io/rubymonsters/slam-alphas.svg?label=ready&title=Ready)](http://waffle.io/rubymonsters/slam-alphas)
 
-# Requirements
+This repo is the open source code for the interactive map of [Slam Alphas](https://slamalphas.org), a collective of women poetry slam artists in Germany, Austria and Switzerland.
+
+For a project overview of the Github issues, please refer to our [Waffle Board](https://waffle.io/rubymonsters/slam-alphas/).
+
+## Requirements
 
 - Ruby 2.2.4


### PR DESCRIPTION
This PR updates the `README.md` with following infos:
- Waffle board link
- short description to `Slam Alphas`

Resolves Github issue: https://github.com/rubymonsters/slam-alphas/issues/60