### PR TITLE
Allow logged-in non-admin users to see themselves and public users an…

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,3 +1,0 @@
-exit
-User.where(public: true)
-continue

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,3 @@
+exit
+User.where(public: true)
+continue

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 
 .DS_Store
+.byebug_history

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,4 +26,12 @@ class ApplicationController < ActionController::Base
   def disallow_unless_admin_or_user(user)
     redirect_to root_url unless signed_in_as_admin? || signed_in_as?(user)
   end
+
+  def visible_users
+    if current_user
+      current_user.visible_for_signed_in_users
+    else
+     User.where(public: true).order("upper(name) ASC")
+   end
+  end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -16,14 +16,7 @@ MARKERS = {"de" => "red", "at" => "blue", "ch" => "turquoise"}
       render plain: "404 Not Found", status: 404
     end
 
-    if current_user.admin?
-     @alphas = User.all
-    else
-     @alphas = (User.where(id: current_user.id) + User.where(public: true)).sort_by {|x| x.name.upcase }
-    end
-
-
-    # @alphas = User.where(public: true).sort_by {|x| x.name.upcase }
+    @alphas = current_user.visible_users
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -16,7 +16,7 @@ MARKERS = {"de" => "red", "at" => "blue", "ch" => "turquoise"}
       render plain: "404 Not Found", status: 404
     end
 
-    @alphas = current_user.visible_users
+    @alphas = visible_users
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -16,7 +16,14 @@ MARKERS = {"de" => "red", "at" => "blue", "ch" => "turquoise"}
       render plain: "404 Not Found", status: 404
     end
 
-    @alphas = User.where(public: true).sort_by {|x| x.name.upcase }
+    if current_user.admin?
+     @alphas = User.all
+    else
+     @alphas = (User.where(id: current_user.id) + User.where(public: true)).sort_by {|x| x.name.upcase }
+    end
+
+
+    # @alphas = User.where(public: true).sort_by {|x| x.name.upcase }
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,12 +21,7 @@ class UsersController < Clearance::UsersController
     @zoom = ZOOMS[@user[:country]]
     @marker = MARKERS[@user[:country]]
 
-    if current_user.admin?
-     @alphas = User.all
-    else
-     @alphas = (User.where(id: current_user.id) + User.where(public: true)).sort_by {|x| x.name.upcase }
-    end
-
+    @alphas = current_user.visible_users
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < Clearance::UsersController
     @zoom = ZOOMS[@user[:country]]
     @marker = MARKERS[@user[:country]]
 
-    @alphas = current_user.visible_users
+    @alphas = visible_users
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,12 @@ class UsersController < Clearance::UsersController
     @zoom = ZOOMS[@user[:country]]
     @marker = MARKERS[@user[:country]]
 
-    @alphas = User.where(public: true).sort_by {|x| x.name }
+    if current_user.admin?
+     @alphas = User.all
+    else
+     @alphas = (User.where(id: current_user.id) + User.where(public: true)).sort_by {|x| x.name.upcase }
+    end
+
     @list = Array.new
 
     @alphas.each do |x|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,19 @@ class User < ActiveRecord::Base
   geocoded_by :location
   after_validation :geocode
 
+# According to the user rights which users is the logged_in user able to see
+  def visible_users
+    if admin?
+      User.all.order("upper(name) ASC")
+    else
+      # Adds the user's id to the array of public ids
+      visible_ids = User.where(public: true).pluck(:id) << id
+      # The logged_in user may see the users whose ids are within the visble ids and they will be sorted ascendingly
+      #with a collation - adding SQL in the query
+      User.where(id: visible_ids).order("upper(name) ASC")
+    end
+  end
+
   def location
     [city, country].compact.join(", ")
   end
@@ -35,5 +48,3 @@ class User < ActiveRecord::Base
   end
 
 end
-
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,8 @@ class User < ActiveRecord::Base
   after_validation :geocode
 
 # According to the user rights which users is the logged_in user able to see
-  def visible_users
-    if admin?
+  def visible_for_signed_in_users
+    if signed_in_as_admin?
       User.all.order("upper(name) ASC")
     else
       # Adds the user's id to the array of public ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
 
 # According to the user rights which users is the logged_in user able to see
   def visible_for_signed_in_users
-    if signed_in_as_admin?
+    if admin?
       User.all.order("upper(name) ASC")
     else
       # Adds the user's id to the array of public ids

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,6 +16,9 @@
           <% end %>
           <%= link_to 'Karte', map_path(country: @user.country) %>
         </p>
+        <% if signed_in_as?(@user) %>
+          <p>You can see your own profile, but it is not public yet</p>
+        <% end %>
     </div>
 </article>
 <div class="l-map">


### PR DESCRIPTION
…d admin users to see all users in maps and users controllers

This PR addresses [78](https://github.com/rubymonsters/slam-alphas/issues/78). 

Instead of adding a scope as suggested in  issue [68](https://github.com/rubymonsters/slam-alphas/issues/68) I added a method #visible_users in the User model.

There is still some duplication in the users and maps controllers, so would be great if we could take care of it.
