### PR TITLE
Update bundler version & readme after upgrade to ruby 2.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,5 +189,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.3.4p301
+
 BUNDLED WITH
-   1.14.3
+   1.15.0

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ For a project overview of the Github issues, please refer to our [Waffle Board](
 
 ## Requirements
 
-- Ruby 2.2.4
+- Ruby 2.3.4


### PR DESCRIPTION
It seems since the recent upgrade to Ruby 2.3.4 it requires to have at least the bundler version 1.15.0 by running `gem bundler update`. This PR checks in the newest bundler version into Github and updates the README.md.