### PR TITLE
use present? instead of empty? in show.html.erb

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,12 +27,12 @@
         <h2 class="title-sub">Verfügbar</h2>
         <p><%= @user.available_at.join(", ") %></p>
       <% end %>
-      <% if !@user.website.empty? || !@user.facebook_link.empty? %>
+      <% if @user.website.present? || @user.facebook_link.present? %>
         <h2 class="title-sub">Kontakt</h2>
-        <% unless @user.website.empty? %>
+        <% if @user.website.present? %>
           <p><a href="<%= @user.website %>" title="Besuche <%= @user.name %>s website"><%= @user.website_clean %></a></p>
         <% end %>
-        <% unless @user.facebook_link.empty? %>
+        <% if @user.facebook_link.present? %>
           <p><a href="<%= @user.facebook_link %>" class="facebook" title="<%= @user.name %> bei Facebook">Facebook-Seite</a></p>
         <% end %>
       <% end %>


### PR DESCRIPTION
When the field "Website" or "Facebook" was empty for a user, the application returned an error message, that the method empty? was not defined. Replacing this method with the method present? should fix this problem.