### PR TITLE
Change from multiple select to multiple checkboxes

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -47,12 +47,13 @@
   </div>
   <div class="form-field field">
     <%= f.label :is_available_on, "Verfügbarkeit" %>
-    <% User::AVAILABLE_OPTIONS.each.with_index do |option, index| %>
+      <small>Aufgrund eines Bugs wird dein letztes Update nicht überschrieben, wenn keine Checkbox aktiviert ist. Bitte achte daher darauf, dass mindst. eine Checkbox aktiviert ist. Wir werden dieses Problem schnellstmöglich beheben.</small>
+      <% User::AVAILABLE_OPTIONS.each.with_index do |option, index| %>
       <%= label_tag "is_available_on_#{index}" do %>
         <%= check_box_tag :'user[is_available_on][]', index, @user.is_available_on.include?(index.to_s), id: "is_available_on_#{index}" %>
         <%= option %>
       <% end %>
-    <% end %>
+  <% end %>
   </div>
   <div class="form-field field">
     <%= f.label :will_travel, "Reisebereitschaft" %><br />

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -47,7 +47,6 @@
   </div>
   <div class="form-field field">
     <%= f.label :is_available_on, "Verfügbarkeit" %>
-    <small>Mehrfachauswahl möglich mit CMD + Maus-Klick (Mac) / STRG + Maus-Klick (Win/Linux)</small>
     <% User::AVAILABLE_OPTIONS.each.with_index do |option, index| %>
       <%= label_tag "is_available_on_#{index}" do %>
         <%= check_box_tag :'user[is_available_on][]', index, @user.is_available_on.include?(index.to_s), id: "is_available_on_#{index}" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -48,7 +48,12 @@
   <div class="form-field field">
     <%= f.label :is_available_on, "Verfügbarkeit" %>
     <small>Mehrfachauswahl möglich mit CMD + Maus-Klick (Mac) / STRG + Maus-Klick (Win/Linux)</small>
-    <%= f.select(:is_available_on, options_for_select(User.available_form_options), {}, multiple: true, size: 7) %>
+    <% User::AVAILABLE_OPTIONS.each.with_index do |option, index| %>
+      <%= label_tag "is_available_on_#{index}" do %>
+        <%= check_box_tag :'user[is_available_on][]', index, @user.is_available_on.include?(index.to_s), id: "is_available_on_#{index}" %>
+        <%= option %>
+      <% end %>
+    <% end %>
   </div>
   <div class="form-field field">
     <%= f.label :will_travel, "Reisebereitschaft" %><br />


### PR DESCRIPTION
This PR changes the param `is_available_on` from multiple selection to checkboxes. At the moment we do not have a separate class for `f.label` in the user edit form. As agreed with @lislis we will create a follow-up ticket for the styling.

<img width="1192" alt="00000355" src="https://user-images.githubusercontent.com/4077916/27803562-63458ed2-602a-11e7-883d-64ba05192924.png">

This PR fixes #129 and is a subtask of #75 .
This will also fix #126 because we are not using multiple selection anymore.
