### PR TITLE
Allow scrolling when slam profile text overlaps the box-element

### DIFF
--- a/app/assets/stylesheets/profile.sass
+++ b/app/assets/stylesheets/profile.sass
@@ -21,6 +21,7 @@ $break: 1300px
 
 .slam-profile
   z-index: 8
+  overflow-y: scroll
   p
     word-wrap: break-word
   header


### PR DESCRIPTION
Minor fix to allow scrolling when text overlaps the `slam-profile` box. There is not ticket yet. 

**Error:**
<img width="1263" alt="00000357" src="https://user-images.githubusercontent.com/4077916/27809047-a934107c-604c-11e7-9943-8823edd43741.png">

**Fix:**
<img width="1259" alt="00000358" src="https://user-images.githubusercontent.com/4077916/27809313-bc6fbb9e-604e-11e7-80bd-856d27c0dd67.png">

