### PR TITLE
adjust padding to match blog

### DIFF
--- a/app/assets/stylesheets/main-wp.css.erb
+++ b/app/assets/stylesheets/main-wp.css.erb
@@ -162,7 +162,7 @@ figure {
   left: 0;
   width: 248px;
   border: 6px solid black;
-  padding: 79px 0 48px;
+  padding: 60px 0 48px;
   background-color: #e63831;
   transition: transform 200ms ease;
   transform: translateX(-100%); }


### PR DESCRIPTION
Adjusted the spacing. We need more space for the extra menu item in the blog which pushes down the facebook button outside most laptop screens. 
This is the same change as on the blog to make them the same again