### PR TITLE
add sign in link to frontpage

### DIFF
--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -51,3 +51,19 @@ $blue: #1837a0
   display: block
   @media (max-width: $break-s)
     display: none
+
+.sign-in-main
+  position: absolute
+  left: 1rem
+  bottom: 1rem
+  padding: 0.5rem 1rem
+  z-index: 999
+  background-color: white
+  border: 5px solid black
+  a
+    text-decoration: none
+    &:hover,
+    &:active,
+    &:focus
+      text-decoration: underline
+      color: currentColor

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -1,12 +1,13 @@
 <main class="l-map is-<%= @country %>">
   <div id="map"><div>
-    <nav class="map-nav is-<%= @country %>">
-      <ul>
-        <li><%= link_to 'DE', map_path('de'), class: "de" %></li>
-        <li><%= link_to 'AT', map_path('at'), class: "at" %></li>
-        <li><%= link_to 'CH', map_path('ch'), class: "ch" %></li>
-      </ul>
-    </nav>
+  <nav class="map-nav is-<%= @country %>">
+    <ul>
+      <li><%= link_to 'DE', map_path('de'), class: "de" %></li>
+      <li><%= link_to 'AT', map_path('at'), class: "at" %></li>
+      <li><%= link_to 'CH', map_path('ch'), class: "ch" %></li>
+    </ul>
+  </nav>
+  <div class="sign-in-main"><%= link_to 'Anmelden', sign_in_path, class: "title-sub" %></div>
 </main>
 
 <script>


### PR DESCRIPTION
<img width="1033" alt="screen shot 2017-08-28 at 19 56 20" src="https://user-images.githubusercontent.com/1006478/29786314-f5729486-8c2a-11e7-8891-85da2f38622c.png">

This will only be visible on the main map views, but if we assume the standard flow is coming from the slam alphas blog and being directly to one of the main map views, this should be fine